### PR TITLE
Scoreboard: add S332 (opspawn compute_score_impact weights)

### DIFF
--- a/bounty-scoreboard.md
+++ b/bounty-scoreboard.md
@@ -73,6 +73,7 @@
 | S329 | @leanderriefel | Split-brain plan persistence (state-scoped vs global load_plan) | PARTIALLY VERIFIED | 5 | 5 | 2 | 4 | Real inconsistency: skip/unskip/reopen derive plan path from --state, but describe/note/focus/reorder/queue/reset/commit-log always use global PLAN_FILE; commit_log_handlers.py line refs wrong (119,171 are load_state not load_plan); only triggers with non-default --state flag; no scoring impact |
 | S330 | @opspawn | JUDGMENT_DETECTORS stale-import excludes plugins | DUPLICATE | 3 | 0 | 0 | 1 | Duplicate of S20 (@dayi1000): same stale frozenset binding via `from registry import JUDGMENT_DETECTORS` in concerns.py; correct Python semantics but zero current impact — no plugin registers needs_judgment=True; S20 already verified this |
 | S331 | @openclawmara | ScoreBundle aggregates silently discarded by _aggregate_scores | VERIFIED | 5 | 5 | 3 | 4 | Both claims confirmed: ScoreBundle computes 4 aggregate scores never read in production (only in tests); _aggregate_scores recomputes independently with semantic disagreement on verified_strict_score (excludes subjective dims, Pipeline 1 includes them); line refs mostly accurate (core.py off by ~20 lines); dead code + wasted computation, no live scoring impact |
+| S332 | @opspawn | compute_score_impact ignores confidence weights | DUPLICATE | 4 | 0 | 1 | 2 | Accurate refs; same core issue as S21 but with correct paths/lines. Impacts only impact-estimate display, not actual scoring. |
 
 ## Scoring Guide
 - **Sig** (1-10): Significance — how meaningful as "poorly engineered"?


### PR DESCRIPTION
Adds scoreboard row for submission verified in xliry/lota-agents#335. Marked as DUPLICATE of S21; refs accurate; impacts only impact-estimate display.